### PR TITLE
Fix for Pynab.Api.update_category_for_month

### DIFF
--- a/pynab/api.py
+++ b/pynab/api.py
@@ -469,7 +469,7 @@ class Api:
         month_id: str = "current",
         category: schemas.Category = None,
         category_id: str = None,
-        request_body: str = None,
+        budgeted: int = 0,
     ):
         """
         Update the budgeted amount for a category in a specific month.
@@ -481,7 +481,7 @@ class Api:
             month_id (str, optional): The ID of the month. Defaults to "current".
             category (schemas.Category, optional): The category object. Defaults to None.
             category_id (str, optional): The ID of the category. Defaults to None.
-            request_body (str, optional): The request body. Defaults to None.
+            budgeted (int, optional): The new value for the amount assigned to this category
 
         Returns:
             schemas.Category: The updated category object.
@@ -493,7 +493,7 @@ class Api:
         month_id = month.month if month else month_id
         category_id = category.id if category else category_id
 
-        request_body = {"category": {"budgeted": 0}}
+        request_body = {"category": {"budgeted": budgeted}}
         response = self.endpoints.request_update_category_for_month(
             budget_id=budget_id,
             month_id=month_id,


### PR DESCRIPTION
`update_category_for_month` took a payload JSON (`request_body` that was never used, and the method would only set the category value for a month to zero.

This patch fixes that by removing the unused `request_body` parameter and adds the `budgeted` integer parameter that is used to set the budget for the specified month.

To maintain backwards compatibility, if the `budgeted` parameter isn't supplied it defaults to zero so the behavior is the same.

API test report below:
```
strident@desktop:~/pynab$ tox
py38: skipped because could not find python interpreter with spec(s): py38
py38: SKIP ⚠ in 0.15 seconds
py39: skipped because could not find python interpreter with spec(s): py39
py39: SKIP ⚠ in 0.09 seconds
.pkg: _optional_hooks> python /home/strident/ObsidianDependencies/pynab/test-venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python /home/strident/ObsidianDependencies/pynab/test-venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python /home/strident/ObsidianDependencies/pynab/test-venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python /home/strident/ObsidianDependencies/pynab/test-venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /home/strident/ObsidianDependencies/pynab/test-venv/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py310: install_package> python -I -m pip install --force-reinstall --no-deps /home/strident/ObsidianDependencies/pynab/.tox/.tmp/package/2/pynab-1.0.0.tar.gz
py310: commands[0]> coverage run -m pytest -s
==================================== test session starts =====================================
platform linux -- Python 3.10.15, pytest-8.3.3, pluggy-1.5.0
cachedir: .tox/py310/.pytest_cache
rootdir: /home/strident/ObsidianDependencies/pynab
collected 34 items                                                                           

testing/test_live_api.py ..................................

===================================== 34 passed in 6.61s =====================================
py310: commands[1]> coverage report -m
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
pynab/__init__.py              3      0   100%
pynab/api.py                 444    110    75%   39-40, 68-74, 79-80, 115-116, 144-145, 186-187, 237-238, 274-275, 318-319, 359-360, 418-419, 461-462, 518-519, 556, 595-596, 641-642, 669-672, 676-677, 701-720, 756-759, 763-764, 807-808, 848-849, 897-898, 923-925, 981, 996-997, 1019-1056, 1079, 1118-1119, 1162-1163, 1201-1202, 1258-1259, 1308-1311, 1314-1315, 1370-1371, 1426-1427, 1472-1473, 1492-1526, 1573-1574
pynab/constants.py             4      0   100%
pynab/endpoints.py           152     28    82%   47, 69, 105, 159, 266, 342-343, 378, 423, 425, 427, 461-462, 561, 563, 565, 592, 594, 596, 623, 625, 627, 654, 656, 658, 677, 694-695
pynab/enums.py                61      0   100%
pynab/pynab.py                22      5    77%   50-53, 63, 73
pynab/schemas.py             561    130    77%   37, 49, 72-79, 88, 192, 218, 229, 259, 271, 285-286, 301-303, 312, 341, 352, 382, 392, 419-421, 430, 461-463, 472, 486-487, 499-502, 511, 543-547, 556, 570-573, 588-591, 601-602, 616-618, 782, 793, 803-804, 816, 828, 964, 974, 985, 997, 1008, 1020, 1041-1050, 1060, 1179, 1189, 1199, 1211, 1223, 1235, 1355, 1404, 1411, 1421, 1431, 1443, 1453, 1463, 1488-1505, 1514, 1524, 1534, 1544, 1554, 1610-1613, 1625, 1654, 1661, 1671, 1681, 1691, 1713-1725, 1735, 1742, 1752, 1762
pynab/utils.py                64     16    75%   38, 60, 82, 104, 125, 146-149, 182-189
testing/__init__.py            0      0   100%
testing/test_live_api.py     356     28    92%   330, 525-526, 552-554, 556-562, 595-598, 868, 1264, 1289-1296, 1312-1315, 1393, 1430-1433
--------------------------------------------------------
TOTAL                       1667    317    81%
py310: commands[2]> coverage html
Wrote HTML report to htmlcov/index.html
  py38: SKIP (0.15 seconds)
  py39: SKIP (0.09 seconds)
  py310: OK (9.53=setup[1.79]+cmd[6.94,0.25,0.56] seconds)
  congratulations :) (9.94 seconds)
```