### PR TITLE
Budget categories infinite loop fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ cython_debug/
 
 # MacOS
 .DS_Store
+
+# Bearer Token
+testing/.env

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 .venv-test
 .venv-docs
 .vscode
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -135,8 +135,13 @@ Follow these steps to manually create a test budget:
 
 ### Running Tests with Tox
 
-Before running tests, update `tests/test_live_api.py` with your API Bearer Token.
+Before running tests, create a `tests/.env` file with your API Bearer Token using the following format:
+```sh
+# ynab personal access token
+API_KEY=your_API_token_goes_here
+```
 
+To run tests:
 ```sh
 python -m venv .venv-test
 source .venv-test/bin/activate

--- a/pynab/schemas.py
+++ b/pynab/schemas.py
@@ -379,7 +379,9 @@ class Budget:
             dict: A dictionary containing the budget's categories.
         """
         if len(self._categories) == 0:
-            self._categories = self.pynab.api.get_budget(budget=self).categories
+            for category_group in self.category_groups.values():
+                for id, category in category_group.categories.items():
+                    self._categories[id] = category
         return self._categories
 
     @property

--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -11,6 +11,7 @@ pluggy==1.5.0
 pyproject-api==1.7.1
 pytest==8.3.3
 python-dateutil==2.9.0.post0
+python-dotenv==1.0.1
 six==1.16.0
 tox==4.18.1
 virtualenv==20.26.4

--- a/testing/test_live_api.py
+++ b/testing/test_live_api.py
@@ -4,6 +4,8 @@ from pynab import Pynab
 from pynab import enums
 import pytest
 import logging
+from dotenv import dotenv_values
+
 
 TEST_BUDGET_NAME = "test_budget"
 TEST_ACCOUNT_NAME = "test_account"
@@ -15,8 +17,9 @@ TEST_TRANSACTION_NAME = "test_transaction"
 TEST_SCHEDULED_TRANSACTION_NAME = "test_scheduled_transaction"
 TEST_PAYEE_CHANGED_NAME = "test_payee_changed"
 
-# Enter API bearer token here
-BEARER = "YOUR_BEARER_TOKEN_HERE"
+# get API bearer token from .env
+secrets = dotenv_values("testing/.env")
+BEARER = secrets["API_KEY"]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Infinite loop condition occurred for `budget.categories` because the `categories.getter` method in `Budget` class would call `api.get_budget.categories`.

This is resolved by instead looping over `category_groups` to compile the full list of `categories`.

Testing results:
```
py38: skipped because could not find python interpreter with spec(s): py38
py38: SKIP ⚠ in 0.01 seconds
.pkg: _optional_hooks> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py39: install_package> python -I -m pip install --force-reinstall --no-deps ~/dev/github.com/sharkwhal/pynab/.tox/.tmp/package/2/pynab-1.0.0.tar.gz
py39: commands[0]> coverage run -m pytest -s
============================================================== test session starts ===============================================================
platform darwin -- Python 3.9.6, pytest-8.3.3, pluggy-1.5.0
cachedir: .tox/py39/.pytest_cache
rootdir: ~/dev/github.com/sharkwhal/pynab
collected 34 items                                                                                                                               

testing/test_live_api.py ..................................

================================================================ warnings summary ================================================================
.tox/py39/lib/python3.9/site-packages/urllib3/__init__.py:35
  ~/dev/github.com/sharkwhal/pynab/.tox/py39/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 34 passed, 1 warning in 5.69s ==========================================================
py39: commands[1]> coverage report -m
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
pynab/__init__.py              3      0   100%
pynab/api.py                 444    110    75%   39-40, 68-74, 79-80, 115-116, 144-145, 186-187, 237-238, 274-275, 318-319, 359-360, 418-419, 461-462, 518-519, 556, 595-596, 641-642, 669-672, 676-677, 701-720, 756-759, 763-764, 807-808, 848-849, 897-898, 923-925, 981, 996-997, 1019-1056, 1079, 1118-1119, 1162-1163, 1201-1202, 1258-1259, 1308-1311, 1314-1315, 1370-1371, 1426-1427, 1472-1473, 1492-1526, 1573-1574
pynab/constants.py             3      0   100%
pynab/endpoints.py           152     28    82%   47, 69, 105, 159, 266, 342-343, 378, 423, 425, 427, 461-462, 561, 563, 565, 592, 594, 596, 623, 625, 627, 654, 656, 658, 677, 694-695
pynab/enums.py                61      0   100%
pynab/pynab.py                22      5    77%   50-53, 63, 73
pynab/schemas.py             562    132    77%   37, 49, 72-79, 88, 192, 218, 229, 259, 271, 285-286, 301-303, 312, 341, 352, 382-384, 394, 421-423, 432, 463-465, 474, 488-489, 501-504, 513, 545-549, 558, 572-575, 590-593, 603-604, 618-620, 784, 795, 805-806, 818, 830, 966, 976, 987, 999, 1010, 1022, 1043-1052, 1062, 1181, 1191, 1201, 1213, 1225, 1237, 1357, 1406, 1413, 1423, 1433, 1445, 1455, 1465, 1490-1507, 1516, 1526, 1536, 1546, 1556, 1612-1615, 1627, 1656, 1663, 1673, 1683, 1693, 1715-1727, 1737, 1744, 1754, 1764
pynab/utils.py                64     16    75%   38, 60, 82, 104, 125, 146-149, 182-189
testing/__init__.py            0      0   100%
testing/test_live_api.py     358     28    92%   333, 528-529, 555-557, 559-565, 598-601, 871, 1267, 1292-1299, 1315-1318, 1396, 1433-1436
--------------------------------------------------------
TOTAL                       1669    319    81%
py39: commands[2]> coverage html
Wrote HTML report to htmlcov/index.html
py39: OK ✔ in 8.63 seconds
py310: skipped because could not find python interpreter with spec(s): py310
  py38: SKIP (0.01 seconds)
  py39: OK (8.62=setup[2.24]+cmd[5.88,0.16,0.35] seconds)
  py310: SKIP (0.01 seconds)
  congratulations :) (8.69 seconds)
```