### PR TITLE
Update api.py to respect pynab _track_server_knowledge option

### DIFF
--- a/pynab/api.py
+++ b/pynab/api.py
@@ -101,7 +101,7 @@ class Api:
 
         response = self.endpoints.request_get_budget(
             budget_id=budget_id,
-            last_knowledge_of_server=self.pynab._server_knowledges["get_budget"],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_budget"),
         )
         _json = response.json()
 
@@ -166,7 +166,7 @@ class Api:
 
         response = self.endpoints.request_get_accounts(
             budget_id=budget_id,
-            last_knowledge_of_server=self.pynab._server_knowledges["get_accounts"],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_accounts"),
         )
         _json = response.json()
 
@@ -297,7 +297,7 @@ class Api:
 
         response = self.endpoints.request_get_categories(
             budget_id=budget_id,
-            last_knowledge_of_server=self.pynab._server_knowledges["get_categories"],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_categories"),
         )
         _json = response.json()
 
@@ -785,7 +785,7 @@ class Api:
 
         response = self.endpoints.request_get_months(
             budget_id=budget_id,
-            last_knowledge_of_server=self.pynab._server_knowledges["get_months"],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_months"),
         )
         _json = response.json()
 
@@ -876,7 +876,7 @@ class Api:
             budget_id=budget_id,
             since_date=since_date,
             type=type,
-            last_knowledge_of_server=self.pynab._server_knowledges["get_transactions"],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_transactions"),
         )
         _json = response.json()
 
@@ -1235,9 +1235,7 @@ class Api:
             account_id=account_id,
             since_date=since_date,
             type=type,
-            last_knowledge_of_server=self.pynab._server_knowledges[
-                "get_account_transactions"
-            ],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_account_transactions"),
         )
         _json = response.json()
 
@@ -1292,9 +1290,7 @@ class Api:
             category_id=category_id,
             since_date=since_date,
             type=type,
-            last_knowledge_of_server=self.pynab._server_knowledges[
-                "get_category_transactions"
-            ],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_category_transactions"),
         )
         _json = response.json()
 
@@ -1348,9 +1344,7 @@ class Api:
             payee_id=payee_id,
             since_date=since_date,
             type=type,
-            last_knowledge_of_server=self.pynab._server_knowledges[
-                "get_payee_transactions"
-            ],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_payee_transactions"),
         )
         _json = response.json()
 
@@ -1404,9 +1398,7 @@ class Api:
             month=month_id,
             since_date=since_date,
             type=type,
-            last_knowledge_of_server=self.pynab._server_knowledges[
-                "get_month_transactions"
-            ],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_month_transactions"),
         )
         _json = response.json()
 
@@ -1449,9 +1441,7 @@ class Api:
 
         response = self.endpoints.request_get_scheduled_transactions(
             budget_id=budget_id,
-            last_knowledge_of_server=self.pynab._server_knowledges[
-                "get_scheduled_transactions"
-            ],
+            last_knowledge_of_server=self.pynab.server_knowledges("get_scheduled_transactions"),
         )
         _json = response.json()
 


### PR DESCRIPTION
Update Api methods to call Pynab.server_knowledges method instead of accessing protected _server_knowledges property directly. This makes the Api methods respect _track_server_knowledge option, which returns 0 when set to False.

Testing results:
```
py38: skipped because could not find python interpreter with spec(s): py38
py38: SKIP ⚠ in 0.17 seconds
.pkg: recreate env because python changed version_info=[3, 13, 1, 'final', 0]->[3, 13, 2, 'final', 0] | executable='/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/bin/python3.13'->'/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/bin/python3.13'
.pkg: remove tox env folder ~/dev/github.com/sharkwhal/pynab/.tox/.pkg
.pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0' wheel
.pkg: _optional_hooks> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_sdist> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_wheel> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: prepare_metadata_for_build_wheel> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python ~/dev/github.com/sharkwhal/pynab/.venv-test/lib/python3.13/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
py39: install_package> python -I -m pip install --force-reinstall --no-deps ~/dev/github.com/sharkwhal/pynab/.tox/.tmp/package/7/pynab-1.0.0.tar.gz
py39: commands[0]> coverage run -m pytest -s
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.9.6, pytest-8.3.3, pluggy-1.5.0
cachedir: .tox/py39/.pytest_cache
rootdir: ~/dev/github.com/sharkwhal/pynab
collected 34 items                                                                                                                                        

testing/test_live_api.py ..................................

==================================================================== warnings summary =====================================================================
.tox/py39/lib/python3.9/site-packages/urllib3/__init__.py:35
  ~/dev/github.com/sharkwhal/pynab/.tox/py39/lib/python3.9/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================== 34 passed, 1 warning in 5.61s ==============================================================
py39: commands[1]> coverage report -m
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
pynab/__init__.py              3      0   100%
pynab/api.py                 444    110    75%   39-40, 68-74, 79-80, 115-116, 144-145, 186-187, 237-238, 274-275, 318-319, 359-360, 418-419, 461-462, 518-519, 556, 595-596, 641-642, 669-672, 676-677, 701-720, 756-759, 763-764, 807-808, 848-849, 897-898, 923-925, 981, 996-997, 1019-1056, 1079, 1118-1119, 1162-1163, 1201-1202, 1256-1257, 1304-1307, 1310-1311, 1364-1365, 1418-1419, 1462-1463, 1482-1516, 1563-1564
pynab/constants.py             3      0   100%
pynab/endpoints.py           152     28    82%   47, 69, 105, 159, 266, 342-343, 378, 423, 425, 427, 461-462, 561, 563, 565, 592, 594, 596, 623, 625, 627, 654, 656, 658, 677, 694-695
pynab/enums.py                61      0   100%
pynab/pynab.py                22      3    86%   51, 63, 73
pynab/schemas.py             562    132    77%   37, 49, 72-79, 88, 192, 218, 229, 259, 271, 285-286, 301-303, 312, 341, 352, 382-384, 394, 421-423, 432, 463-465, 474, 488-489, 501-504, 513, 545-549, 558, 572-575, 590-593, 603-604, 618-620, 784, 795, 805-806, 818, 830, 966, 976, 987, 999, 1010, 1022, 1043-1052, 1062, 1181, 1191, 1201, 1213, 1225, 1237, 1357, 1406, 1413, 1423, 1433, 1445, 1455, 1465, 1490-1507, 1516, 1526, 1536, 1546, 1556, 1612-1615, 1627, 1656, 1663, 1673, 1683, 1693, 1715-1727, 1737, 1744, 1754, 1764
pynab/utils.py                64     16    75%   34, 56, 78, 100, 121, 146-149, 182-189
testing/__init__.py            0      0   100%
testing/test_live_api.py     358     28    92%   333, 528-529, 555-557, 559-565, 598-601, 871, 1267, 1292-1299, 1315-1318, 1396, 1433-1436
--------------------------------------------------------
TOTAL                       1669    317    81%
py39: commands[2]> coverage html
Wrote HTML report to htmlcov/index.html
py39: OK ✔ in 10.56 seconds
py310: skipped because could not find python interpreter with spec(s): py310
  py38: SKIP (0.17 seconds)
  py39: OK (10.56=setup[4.18]+cmd[5.83,0.19,0.36] seconds)
  py310: SKIP (0.01 seconds)
  congratulations :) (10.79 seconds)
```